### PR TITLE
:sparkles: 搜索和下载不同服务器的模型.

### DIFF
--- a/cmd/bestdori-live2d-downloader/main.go
+++ b/cmd/bestdori-live2d-downloader/main.go
@@ -100,18 +100,15 @@ func (a *App) getLive2dPath(live2dName string) (string, error) {
 		return "", errors.New("无效的Live2D名称格式")
 	}
 
-	// 依次尝试每一段，直到找到可解析为数字的角色ID
-	var charaID int
-	var err error
+	// 找到第一个可解析的角色ID位置
 	foundIdx := -1
-	var costumePrefix strings.Builder
+	var charaID int
 	for i, p := range parts {
-		charaID, err = strconv.Atoi(p)
+		id, err := strconv.Atoi(p)
 		if err == nil {
 			foundIdx = i
+			charaID = id
 			break
-		} else {
-			costumePrefix.WriteString(p + "_")
 		}
 	}
 	if foundIdx == -1 {
@@ -125,12 +122,13 @@ func (a *App) getLive2dPath(live2dName string) (string, error) {
 		return "", errors.New("无效的Live2D名称格式: 缺少服装部分")
 	}
 
-	costumePart := strings.Join(parts[foundIdx+1:], "_")
+	prefix := strings.Join(parts[:foundIdx], "_")        // 可能为空
+	costumePart := strings.Join(parts[foundIdx+1:], "_") // 服装部分
+	costume := strings.Trim(strings.Join([]string{prefix, costumePart}, "_"), "_")
 
-	// 尝试获取角色信息
+	// 后续逻辑仅使用 charaID 和 costume
 	chara, err := a.apiClient.GetChara(a.ctx, charaID)
 	if err != nil {
-		// 如果获取角色信息失败，使用角色ID作为目录名
 		log.DefaultLogger.Warn().Int("charaID", charaID).Err(err).Msg("获取角色信息失败，使用角色ID作为目录名")
 		path := filepath.Join(config.Get().Live2dSavePath, fmt.Sprintf("chara_%03d", charaID), costumePart)
 		log.DefaultLogger.Info().Str("path", path).Msg("获取Live2D路径成功")
@@ -147,7 +145,6 @@ func (a *App) getLive2dPath(live2dName string) (string, error) {
 		return path, nil
 	}
 
-	costume := costumePrefix.String() + costumePart
 	path := filepath.Join(config.Get().Live2dSavePath, strings.ToLower(firstName), costume)
 	log.DefaultLogger.Info().Str("path", path).Msg("获取Live2D路径成功")
 	return path, nil

--- a/cmd/bestdori-live2d-downloader/main.go
+++ b/cmd/bestdori-live2d-downloader/main.go
@@ -386,6 +386,19 @@ func (a *App) resolveDirectDownloadAssets(modelNames []string) ([]*model.Live2dA
 	return assets, invalidModels, nil
 }
 
+func (a *App) shouldHandleAsDirectDownload(input string) (bool, error) {
+	if input == "" {
+		return false, nil
+	}
+
+	_, exists, err := a.apiClient.GetLive2dAsset(a.ctx, input)
+	if err != nil {
+		return false, fmt.Errorf("验证模型失败: %w", err)
+	}
+
+	return exists, nil
+}
+
 // handleDirectDownload 处理直接下载请求.
 func (a *App) handleDirectDownload(input string) bool {
 	log.DefaultLogger.Info().Str("input", input).Msg("开始直接下载Live2D")
@@ -444,12 +457,16 @@ func (a *App) handleDownload(input string) bool {
 		return a.handleCharaIDSearch(input)
 	}
 
-	// 先尝试作为 Live2D 模型名称处理
-	parts := strings.SplitN(input, "_", SplitPartsCount)
-	if len(parts) >= 2 {
-		if _, err := strconv.Atoi(parts[0]); err == nil {
-			return a.handleDirectDownload(input)
-		}
+	// 优先按完整模型名称处理，再回退到角色搜索
+	direct, err := a.shouldHandleAsDirectDownload(input)
+	if err != nil {
+		log.DefaultLogger.Error().Str("input", input).Err(err).Msg("验证模型失败")
+		a.tuiModel.SetError(err.Error())
+		a.tuiModel.State = StateInput
+		return true
+	}
+	if direct {
+		return a.handleDirectDownload(input)
 	}
 
 	// 如果不是模型名称，则尝试角色搜索

--- a/cmd/bestdori-live2d-downloader/main.go
+++ b/cmd/bestdori-live2d-downloader/main.go
@@ -263,9 +263,11 @@ func (a *App) updateCharaCostumes(id int, firstName string, displayName string) 
 	// 清除之前的错误消息
 	a.tuiModel.ClearError()
 
-	var costumeNames []string
+	var costumeAssets []*model.Live2dAsset
 	for _, live2d := range costumes {
-		costumeNames = append(costumeNames, live2d.String())
+		// create a copy to take address
+		aCopy := live2d
+		costumeAssets = append(costumeAssets, &aCopy)
 	}
 
 	// 更新列表
@@ -279,7 +281,7 @@ func (a *App) updateCharaCostumes(id int, firstName string, displayName string) 
 		Str("charaName", firstName).
 		Int("costumesCount", len(costumes)).
 		Msg("找到角色服装列表")
-	a.program.Send(tui.UpdateListMsg{Items: costumeNames})
+	a.program.Send(tui.UpdateListMsg{Items: costumeAssets})
 
 	return true
 }
@@ -419,17 +421,17 @@ func (a *App) handleDirectDownload(input string) bool {
 	a.tuiModel.DownloadList.Title = "下载进度"
 
 	// TODO: 可选 Bestdori 服务器
-	// 设置默认服务器
-	for i, costume := range modelNames {
-		model := model.Live2dAsset{
+	// 设置默认服务器并构建资产对象列表
+	assets := make([]*model.Live2dAsset, 0, len(modelNames))
+	for _, costume := range modelNames {
+		assets = append(assets, &model.Live2dAsset{
 			Server:  a.apiClient.GetDefaultAssetServer(),
 			Costume: costume,
-		}
-		modelNames[i] = model.String()
+		})
 	}
 
 	// 使用批量下载功能处理多个模型
-	return a.handleBatchDownload(modelNames)
+	return a.handleBatchDownload(assets)
 }
 
 // handleDownload 处理下载请求.
@@ -454,22 +456,24 @@ func (a *App) handleDownload(input string) bool {
 
 // downloadModel 下载单个模型.
 func (a *App) downloadModel(
-	costume string,
+	asset *model.Live2dAsset,
 	errChan chan error,
 	completed map[string]bool,
 	progressUpdated chan struct{},
 ) {
-	// 从格式化字符串读取模型信息
-	model, _ := model.Parse(costume) // 错误会在 downloadLive2d 抛出
+	name := ""
+	if asset != nil {
+		name = asset.String()
+	}
 
-	if err := a.downloadLive2d(model); err != nil {
+	if err := a.downloadLive2d(asset); err != nil {
 		if err.Error() == ErrDownloadCancelled {
 			errChan <- err
 			return
 		}
-		log.DefaultLogger.Error().Str("model", costume).Err(err).Msg("下载失败")
+		log.DefaultLogger.Error().Str("model", name).Err(err).Msg("下载失败")
 	} else {
-		completed[costume] = true
+		completed[name] = true
 	}
 	// 无论成功还是失败，都更新总体进度
 	a.tuiModel.UpdateTotalProgress()
@@ -481,7 +485,7 @@ func (a *App) downloadModel(
 }
 
 // handleBatchDownload 处理批量下载请求.
-func (a *App) handleBatchDownload(selectedItems []string) bool {
+func (a *App) handleBatchDownload(selectedItems []*model.Live2dAsset) bool {
 	if len(selectedItems) == 0 {
 		return true
 	}
@@ -496,7 +500,7 @@ func (a *App) handleBatchDownload(selectedItems []string) bool {
 	modelSem := make(chan struct{}, config.Get().MaxConcurrentModels)
 	progressUpdated := make(chan struct{}, 1) // 用于通知进度已更新
 
-	for _, costume := range selectedItems {
+	for _, asset := range selectedItems {
 		select {
 		case <-a.ctx.Done():
 			a.handleCancelledDownloads(selectedItems, completed)
@@ -510,10 +514,10 @@ func (a *App) handleBatchDownload(selectedItems []string) bool {
 			continue
 		default:
 			modelSem <- struct{}{}
-			go func(costume string) {
+			go func(asset *model.Live2dAsset) {
 				defer func() { <-modelSem }()
-				a.downloadModel(costume, errChan, completed, progressUpdated)
-			}(costume)
+				a.downloadModel(asset, errChan, completed, progressUpdated)
+			}(asset)
 		}
 	}
 
@@ -525,10 +529,14 @@ func (a *App) handleBatchDownload(selectedItems []string) bool {
 }
 
 // handleCancelledDownloads 处理已取消的下载.
-func (a *App) handleCancelledDownloads(selectedItems []string, completed map[string]bool) {
-	for _, item := range selectedItems {
-		if !completed[item] {
-			log.DefaultLogger.Error().Str("model", item).Msg("下载已取消")
+func (a *App) handleCancelledDownloads(selectedItems []*model.Live2dAsset, completed map[string]bool) {
+	for _, asset := range selectedItems {
+		name := ""
+		if asset != nil {
+			name = asset.String()
+		}
+		if !completed[name] {
+			log.DefaultLogger.Error().Str("model", name).Msg("下载已取消")
 			// 注意：总体进度已经在downloadModel中更新，这里不需要重复更新
 		}
 	}

--- a/cmd/bestdori-live2d-downloader/main.go
+++ b/cmd/bestdori-live2d-downloader/main.go
@@ -94,24 +94,45 @@ func (a *App) initialize() {
 
 // getLive2dPath 根据 Live2D 名称获取保存路径.
 func (a *App) getLive2dPath(live2dName string) (string, error) {
-	parts := strings.SplitN(live2dName, "_", SplitPartsCount)
-	if len(parts) != SplitPartsCount {
+	parts := strings.Split(live2dName, "_")
+	if len(parts) == 0 {
 		log.DefaultLogger.Error().Str("live2dName", live2dName).Msg("无效的Live2D名称格式")
 		return "", errors.New("无效的Live2D名称格式")
 	}
 
-	charaID, err := strconv.Atoi(parts[0])
-	if err != nil {
-		log.DefaultLogger.Error().Str("live2dName", live2dName).Err(err).Msg("无效的角色ID")
-		return "", fmt.Errorf("无效的角色ID: %w", err)
+	// 依次尝试每一段，直到找到可解析为数字的角色ID
+	costumePrefix := ""
+	var charaID int
+	var err error
+	foundIdx := -1
+	for i, p := range parts {
+		charaID, err = strconv.Atoi(p)
+		if err == nil {
+			foundIdx = i
+			break
+		} else {
+			costumePrefix += p + "_"
+		}
 	}
+	if foundIdx == -1 {
+		log.DefaultLogger.Error().Str("live2dName", live2dName).Msg("未找到可解析为数字的角色ID")
+		return "", errors.New("无效的角色ID: 未找到可解析为数字的部分")
+	}
+
+	// 角色ID 后必须还有服装部分
+	if foundIdx >= len(parts)-1 {
+		log.DefaultLogger.Error().Str("live2dName", live2dName).Msg("无效的Live2D名称格式: 缺少服装部分")
+		return "", errors.New("无效的Live2D名称格式: 缺少服装部分")
+	}
+
+	costumePart := strings.Join(parts[foundIdx+1:], "_")
 
 	// 尝试获取角色信息
 	chara, err := a.apiClient.GetChara(a.ctx, charaID)
 	if err != nil {
 		// 如果获取角色信息失败，使用角色ID作为目录名
 		log.DefaultLogger.Warn().Int("charaID", charaID).Err(err).Msg("获取角色信息失败，使用角色ID作为目录名")
-		path := filepath.Join(config.Get().Live2dSavePath, fmt.Sprintf("chara_%03d", charaID), parts[1])
+		path := filepath.Join(config.Get().Live2dSavePath, fmt.Sprintf("chara_%03d", charaID), costumePart)
 		log.DefaultLogger.Info().Str("path", path).Msg("获取Live2D路径成功")
 		return path, nil
 	}
@@ -121,38 +142,39 @@ func (a *App) getLive2dPath(live2dName string) (string, error) {
 	if !ok {
 		// 如果无法获取角色名，使用角色ID作为目录名
 		log.DefaultLogger.Warn().Int("charaID", charaID).Msg("无效的角色名字格式，使用角色ID作为目录名")
-		path := filepath.Join(config.Get().Live2dSavePath, fmt.Sprintf("chara_%03d", charaID), parts[1])
+		path := filepath.Join(config.Get().Live2dSavePath, fmt.Sprintf("chara_%03d", charaID), costumePart)
 		log.DefaultLogger.Info().Str("path", path).Msg("获取Live2D路径成功")
 		return path, nil
 	}
 
-	path := filepath.Join(config.Get().Live2dSavePath, strings.ToLower(firstName), parts[1])
+	costume := costumePrefix + costumePart
+	path := filepath.Join(config.Get().Live2dSavePath, strings.ToLower(firstName), costume)
 	log.DefaultLogger.Info().Str("path", path).Msg("获取Live2D路径成功")
 	return path, nil
 }
 
 // downloadLive2d 下载指定的 Live2D 模型.
-func (a *App) downloadLive2d(live2dName string) error {
-	log.DefaultLogger.Info().Str("live2dName", live2dName).Msg("开始下载Live2D")
+func (a *App) downloadLive2d(live2d *model.Live2dAsset) error {
+	log.DefaultLogger.Info().Str("live2dName", live2d.Costume).Msg("开始下载Live2D")
 
-	data, err := a.apiClient.GetLive2dData(a.ctx, live2dName)
+	server, data, err := a.apiClient.GetLive2dData(a.ctx, live2d)
 	if err != nil {
-		log.DefaultLogger.Error().Str("live2dName", live2dName).Err(err).Msg("获取Live2D数据失败")
+		log.DefaultLogger.Error().Str("live2dName", live2d.Costume).Err(err).Msg("获取Live2D数据失败")
 		return fmt.Errorf("获取Live2D数据失败: %w", err)
 	}
 
-	path, err := a.getLive2dPath(live2dName)
+	path, err := a.getLive2dPath(live2d.Costume)
 	if err != nil {
 		return err
 	}
 
-	builder := downloader.NewLive2dBuilder(path, data, a.dl, live2dName)
+	builder := downloader.NewLive2dBuilder(path, server, data, a.dl, live2d.String())
 	if constructErr := builder.Construct(); constructErr != nil {
-		log.DefaultLogger.Error().Str("live2dName", live2dName).Err(constructErr).Msg("构建Live2D模型失败")
+		log.DefaultLogger.Error().Str("live2dName", live2d.Costume).Err(constructErr).Msg("构建Live2D模型失败")
 		return fmt.Errorf("构建Live2D模型失败: %w", constructErr)
 	}
 
-	log.DefaultLogger.Info().Str("live2dName", live2dName).Str("path", path).Msg("Live2D下载完成")
+	log.DefaultLogger.Info().Str("live2dName", live2d.Costume).Str("path", path).Msg("Live2D下载完成")
 	return nil
 }
 
@@ -244,6 +266,11 @@ func (a *App) updateCharaCostumes(id int, firstName string, displayName string) 
 	// 清除之前的错误消息
 	a.tuiModel.ClearError()
 
+	var costumeNames []string
+	for _, live2d := range costumes {
+		costumeNames = append(costumeNames, live2d.String())
+	}
+
 	// 更新列表
 	a.tuiModel.CurrentCharaName = firstName
 	if displayName != firstName {
@@ -255,7 +282,7 @@ func (a *App) updateCharaCostumes(id int, firstName string, displayName string) 
 		Str("charaName", firstName).
 		Int("costumesCount", len(costumes)).
 		Msg("找到角色服装列表")
-	a.program.Send(tui.UpdateListMsg{Items: costumes})
+	a.program.Send(tui.UpdateListMsg{Items: costumeNames})
 
 	return true
 }
@@ -394,6 +421,16 @@ func (a *App) handleDirectDownload(input string) bool {
 	a.tuiModel.State = "downloading"
 	a.tuiModel.DownloadList.Title = "下载进度"
 
+	// TODO: 可选 Bestdori 服务器
+	// 设置默认服务器
+	for i, costume := range modelNames {
+		model := model.Live2dAsset{
+			Server:  a.apiClient.GetDefaultAssetServer(),
+			Costume: costume,
+		}
+		modelNames[i] = model.String()
+	}
+
 	// 使用批量下载功能处理多个模型
 	return a.handleBatchDownload(modelNames)
 }
@@ -425,7 +462,10 @@ func (a *App) downloadModel(
 	completed map[string]bool,
 	progressUpdated chan struct{},
 ) {
-	if err := a.downloadLive2d(costume); err != nil {
+	// 从格式化字符串读取模型信息
+	model, _ := model.Parse(costume) // 错误会在 downloadLive2d 抛出
+
+	if err := a.downloadLive2d(model); err != nil {
 		if err.Error() == ErrDownloadCancelled {
 			errChan <- err
 			return

--- a/cmd/bestdori-live2d-downloader/main.go
+++ b/cmd/bestdori-live2d-downloader/main.go
@@ -367,6 +367,25 @@ func (a *App) handleCharaSearch(input string) bool {
 	return a.updateCharaCostumes(matchChara.ID, matchChara.Name, displayName)
 }
 
+func (a *App) resolveDirectDownloadAssets(modelNames []string) ([]*model.Live2dAsset, []string, error) {
+	assets := make([]*model.Live2dAsset, 0, len(modelNames))
+	invalidModels := make([]string, 0)
+
+	for _, name := range modelNames {
+		asset, exists, err := a.apiClient.GetLive2dAsset(a.ctx, name)
+		if err != nil {
+			return nil, nil, fmt.Errorf("验证模型失败: %w", err)
+		}
+		if !exists {
+			invalidModels = append(invalidModels, name)
+			continue
+		}
+		assets = append(assets, asset)
+	}
+
+	return assets, invalidModels, nil
+}
+
 // handleDirectDownload 处理直接下载请求.
 func (a *App) handleDirectDownload(input string) bool {
 	log.DefaultLogger.Info().Str("input", input).Msg("开始直接下载Live2D")
@@ -393,19 +412,12 @@ func (a *App) handleDirectDownload(input string) bool {
 		return true
 	}
 
-	// 验证所有模型是否存在
-	var invalidModels []string
-	for _, name := range modelNames {
-		exists, err := a.apiClient.ValidateLive2dModel(a.ctx, name)
-		if err != nil {
-			log.DefaultLogger.Error().Str("model", name).Err(err).Msg("验证模型失败")
-			a.tuiModel.SetError(fmt.Sprintf("验证模型失败: %v", err))
-			a.tuiModel.State = StateInput
-			return true
-		}
-		if !exists {
-			invalidModels = append(invalidModels, name)
-		}
+	assets, invalidModels, err := a.resolveDirectDownloadAssets(modelNames)
+	if err != nil {
+		log.DefaultLogger.Error().Strs("models", modelNames).Err(err).Msg("验证模型失败")
+		a.tuiModel.SetError(err.Error())
+		a.tuiModel.State = StateInput
+		return true
 	}
 
 	// 如果有无效的模型，显示错误信息
@@ -419,16 +431,6 @@ func (a *App) handleDirectDownload(input string) bool {
 
 	a.tuiModel.State = "downloading"
 	a.tuiModel.DownloadList.Title = "下载进度"
-
-	// TODO: 可选 Bestdori 服务器
-	// 设置默认服务器并构建资产对象列表
-	assets := make([]*model.Live2dAsset, 0, len(modelNames))
-	for _, costume := range modelNames {
-		assets = append(assets, &model.Live2dAsset{
-			Server:  a.apiClient.GetDefaultAssetServer(),
-			Costume: costume,
-		})
-	}
 
 	// 使用批量下载功能处理多个模型
 	return a.handleBatchDownload(assets)

--- a/cmd/bestdori-live2d-downloader/main.go
+++ b/cmd/bestdori-live2d-downloader/main.go
@@ -101,17 +101,17 @@ func (a *App) getLive2dPath(live2dName string) (string, error) {
 	}
 
 	// 依次尝试每一段，直到找到可解析为数字的角色ID
-	costumePrefix := ""
 	var charaID int
 	var err error
 	foundIdx := -1
+	var costumePrefix strings.Builder
 	for i, p := range parts {
 		charaID, err = strconv.Atoi(p)
 		if err == nil {
 			foundIdx = i
 			break
 		} else {
-			costumePrefix += p + "_"
+			costumePrefix.WriteString(p + "_")
 		}
 	}
 	if foundIdx == -1 {
@@ -147,7 +147,7 @@ func (a *App) getLive2dPath(live2dName string) (string, error) {
 		return path, nil
 	}
 
-	costume := costumePrefix + costumePart
+	costume := costumePrefix.String() + costumePart
 	path := filepath.Join(config.Get().Live2dSavePath, strings.ToLower(firstName), costume)
 	log.DefaultLogger.Info().Str("path", path).Msg("获取Live2D路径成功")
 	return path, nil

--- a/cmd/bestdori-live2d-downloader/main_test.go
+++ b/cmd/bestdori-live2d-downloader/main_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/A-kirami/bestdori-live2d-downloader/pkg/api"
+	"github.com/A-kirami/bestdori-live2d-downloader/pkg/config"
+	"github.com/A-kirami/bestdori-live2d-downloader/pkg/log"
+	"github.com/stretchr/testify/require"
+)
+
+func setupDirectDownloadTestClient(
+	t *testing.T,
+	assetServers map[string]map[string]any,
+) *api.Client {
+	t.Helper()
+
+	config.Init()
+	cfg := config.Get()
+	logDir, err := os.MkdirTemp("", "bestdori-main-test-logs-*")
+	require.NoError(t, err)
+	cfg.LogPath = logDir
+	cfg.ServerTags = make([]string, 0, len(assetServers))
+	cfg.AssetServers = make(map[string]config.AssetServerConfig, len(assetServers))
+	_, err = log.New(cfg.LogPath)
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	for tag, costumes := range assetServers {
+		cfg.ServerTags = append(cfg.ServerTags, tag)
+		cfg.AssetServers[tag] = config.AssetServerConfig{
+			BaseAssetsURL:  "https://example.invalid/assets/" + tag,
+			AssetsIndexURL: "http://example.invalid/" + tag + "/assets/_info.json",
+		}
+
+		response := map[string]any{
+			"live2d": map[string]any{
+				"chara": costumes,
+			},
+		}
+
+		path := "/" + tag + "/assets/_info.json"
+		mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(response))
+		})
+	}
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	for tag, serverCfg := range cfg.AssetServers {
+		serverCfg.AssetsIndexURL = server.URL + "/" + tag + "/assets/_info.json"
+		cfg.AssetServers[tag] = serverCfg
+	}
+
+	client := api.NewClient()
+	client.SetUseCharaCache(false)
+	client.SetCharaCachePath(t.TempDir())
+	return client
+}
+
+func TestResolveDirectDownloadAssetsUsesResolvedServer(t *testing.T) {
+	client := setupDirectDownloadTestClient(t, map[string]map[string]any{
+		"jp": {},
+		"cn": {
+			"037_casual-2023": map[string]any{},
+		},
+	})
+	app := &App{
+		ctx:       context.Background(),
+		apiClient: client,
+	}
+
+	assets, invalidModels, err := app.resolveDirectDownloadAssets([]string{"037_casual-2023"})
+
+	require.NoError(t, err)
+	require.Empty(t, invalidModels)
+	require.Len(t, assets, 1)
+	require.Equal(t, "cn", assets[0].Server)
+	require.Equal(t, "037_casual-2023", assets[0].Costume)
+}

--- a/cmd/bestdori-live2d-downloader/main_test.go
+++ b/cmd/bestdori-live2d-downloader/main_test.go
@@ -84,3 +84,54 @@ func TestResolveDirectDownloadAssetsUsesResolvedServer(t *testing.T) {
 	require.Equal(t, "cn", assets[0].Server)
 	require.Equal(t, "037_casual-2023", assets[0].Costume)
 }
+
+func TestShouldHandleAsDirectDownloadSupportsBiliSpecialModels(t *testing.T) {
+	client := setupDirectDownloadTestClient(t, map[string]map[string]any{
+		"jp": {
+			"bili_001_collabo_r": map[string]any{},
+		},
+	})
+	app := &App{
+		ctx:       context.Background(),
+		apiClient: client,
+	}
+
+	direct, err := app.shouldHandleAsDirectDownload("bili_001_collabo_r")
+
+	require.NoError(t, err)
+	require.True(t, direct)
+}
+
+func TestShouldHandleAsDirectDownloadSupportsRegularModelNames(t *testing.T) {
+	client := setupDirectDownloadTestClient(t, map[string]map[string]any{
+		"jp": {
+			"037_casual-2023": map[string]any{},
+		},
+	})
+	app := &App{
+		ctx:       context.Background(),
+		apiClient: client,
+	}
+
+	direct, err := app.shouldHandleAsDirectDownload("037_casual-2023")
+
+	require.NoError(t, err)
+	require.True(t, direct)
+}
+
+func TestShouldHandleAsDirectDownloadFallsBackForPlainText(t *testing.T) {
+	client := setupDirectDownloadTestClient(t, map[string]map[string]any{
+		"jp": {
+			"037_casual-2023": map[string]any{},
+		},
+	})
+	app := &App{
+		ctx:       context.Background(),
+		apiClient: client,
+	}
+
+	direct, err := app.shouldHandleAsDirectDownload("kasumi")
+
+	require.NoError(t, err)
+	require.False(t, direct)
+}

--- a/cmd/bestdori-live2d-downloader/main_test.go
+++ b/cmd/bestdori-live2d-downloader/main_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/A-kirami/bestdori-live2d-downloader/pkg/api"
@@ -22,13 +21,16 @@ func setupDirectDownloadTestClient(
 
 	config.Init()
 	cfg := config.Get()
-	logDir, err := os.MkdirTemp("", "bestdori-main-test-logs-*")
-	require.NoError(t, err)
-	cfg.LogPath = logDir
+	cfg.LogPath = t.TempDir()
 	cfg.ServerTags = make([]string, 0, len(assetServers))
 	cfg.AssetServers = make(map[string]config.AssetServerConfig, len(assetServers))
-	_, err = log.New(cfg.LogPath)
+	logger, err := log.New(cfg.LogPath)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		if closeErr := logger.Close(); closeErr != nil {
+			t.Errorf("close logger: %v", closeErr)
+		}
+	})
 
 	mux := http.NewServeMux()
 	for tag, costumes := range assetServers {
@@ -46,7 +48,9 @@ func setupDirectDownloadTestClient(
 
 		path := "/" + tag + "/assets/_info.json"
 		mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
-			require.NoError(t, json.NewEncoder(w).Encode(response))
+			if encodeErr := json.NewEncoder(w).Encode(response); encodeErr != nil {
+				t.Errorf("encode %s response: %v", path, encodeErr)
+			}
 		})
 	}
 

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -1,6 +1,6 @@
 // Package api 提供了与 Bestdori API 交互的功能
 // 包括获取角色信息、Live2D 模型数据等功能
-package api //nolint:revive // package name 'api' reflects the import path and package responsibility
+package api
 
 import (
 	"context"

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -1,6 +1,6 @@
 // Package api 提供了与 Bestdori API 交互的功能
 // 包括获取角色信息、Live2D 模型数据等功能
-package api
+package api //nolint:revive // package name 'api' reflects the import path and package responsibility
 
 import (
 	"context"
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -103,6 +102,7 @@ func (c *Client) FetchData(ctx context.Context, url string, cache string) (map[s
 		return nil, fmt.Errorf("创建请求失败: %w", err)
 	}
 
+	// #nosec G704 -- 请求的 URL 源自配置或受控输入，已在调用方或配置中验证
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		log.DefaultLogger.Error().Str("url", url).Err(err).Msg("获取数据失败")
@@ -214,7 +214,7 @@ func (c *Client) getLive2dAssets(ctx context.Context) (map[string]string, error)
 		}
 
 		for costume := range newLive2dAssets {
-			if _, o := live2dAssets[costume]; !o {
+			if _, exists := live2dAssets[costume]; !exists {
 				live2dAssets[costume] = tag
 			}
 		}
@@ -260,31 +260,9 @@ func (c *Client) GetCharaCostumes(ctx context.Context, charaID int) ([]model.Liv
 		}
 	}
 
-	// 对服装列表进行排序
+	// 对服装列表进行排序 (使用 model 包中的比较函数)
 	sort.Slice(costumes, func(i, j int) bool {
-		// 提取服装ID（模型名称中的数字部分）
-		iParts := strings.Split(costumes[i].Costume, "_")
-		jParts := strings.Split(costumes[j].Costume, "_")
-
-		// 如果包含"live_event"，将其排在后面
-		iHasEvent := strings.Contains(costumes[i].Costume, "live_event")
-		jHasEvent := strings.Contains(costumes[j].Costume, "live_event")
-
-		if iHasEvent != jHasEvent {
-			return !iHasEvent
-		}
-
-		// 比较服装ID
-		if len(iParts) > 1 && len(jParts) > 1 {
-			iID, iErr := strconv.Atoi(iParts[1])
-			jID, jErr := strconv.Atoi(jParts[1])
-			if iErr == nil && jErr == nil {
-				return iID < jID
-			}
-		}
-
-		// 如果无法比较ID，则按字符串排序
-		return costumes[i].Costume < costumes[j].Costume
+		return model.CostumeLess(costumes[i], costumes[j])
 	})
 
 	return costumes, nil

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -23,13 +23,13 @@ import (
 // Client 表示 API 客户端
 // 负责处理与 Bestdori API 的所有交互.
 type Client struct {
-	useCharaCache  bool          // 是否使用角色信息缓存
-	charaCachePath string        // 角色信息缓存路径
-	cacheDuration  time.Duration // 缓存过期时间
-	baseAssetsURL  string        // Bestdori 资源基础 URL
-	charaRosterURL string        // 角色信息 API URL
-	assetsIndexURL string        // 资源索引 API URL
-	httpClient     *http.Client  // HTTP 客户端
+	useCharaCache      bool                                // 是否使用角色信息缓存
+	charaCachePath     string                              // 角色信息缓存路径
+	cacheDuration      time.Duration                       // 缓存过期时间
+	charaRosterURL     string                              // 角色信息 API URL
+	defaultAssetServer string                              // 默认 Bestdori 资源服务器标签
+	assetServers       map[string]config.AssetServerConfig // Bestdori 资源服务器配置
+	httpClient         *http.Client                        // HTTP 客户端
 }
 
 // NewClient 创建新的 API 客户端实例
@@ -37,13 +37,14 @@ type Client struct {
 //   - *Client: 新的 API 客户端实例
 func NewClient() *Client {
 	cfg := config.Get()
+	// s, _ := cfg.AssetServers[cfg.DefaultAssetServer]
 	return &Client{
-		useCharaCache:  cfg.UseCharaCache,
-		charaCachePath: cfg.CharaCachePath,
-		cacheDuration:  cfg.CacheDuration,
-		baseAssetsURL:  cfg.BaseAssetsURL,
-		charaRosterURL: cfg.CharaRosterURL,
-		assetsIndexURL: cfg.AssetsIndexURL,
+		useCharaCache:      cfg.UseCharaCache,
+		charaCachePath:     cfg.CharaCachePath,
+		cacheDuration:      cfg.CacheDuration,
+		charaRosterURL:     cfg.CharaRosterURL,
+		defaultAssetServer: cfg.DefaultAssetServer,
+		assetServers:       cfg.AssetServers,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -164,15 +165,17 @@ func (c *Client) GetChara(ctx context.Context, charaID int) (map[string]any, err
 	return c.FetchData(ctx, url, fmt.Sprintf("chara_%d.json", charaID))
 }
 
-// getLive2dAssets 获取 Live2D 资源映射
+// getSingleLive2dAssets 获取单个资源服务器的 Live2D 资源映射
 // 参数:
 //   - ctx: 上下文
+//   - tag: 服务器标签
+//   - s: Bestdori 资源服务器
 //
 // 返回:
 //   - map[string]any: Live2D 资源映射
 //   - error: 错误信息
-func (c *Client) getLive2dAssets(ctx context.Context) (map[string]any, error) {
-	assetsInfo, err := c.FetchData(ctx, c.assetsIndexURL, "assets_info.json")
+func (c *Client) getSingleLive2dAssets(ctx context.Context, tag string, s *config.AssetServerConfig) (map[string]any, error) {
+	assetsInfo, err := c.FetchData(ctx, s.AssetsIndexURL, fmt.Sprintf("assets_info_%s.json", tag))
 	if err != nil {
 		return nil, err
 	}
@@ -180,6 +183,32 @@ func (c *Client) getLive2dAssets(ctx context.Context) (map[string]any, error) {
 	live2dAssets, ok := assetsInfo["live2d"].(map[string]any)["chara"].(map[string]any)
 	if !ok {
 		return nil, errors.New("无效的资源索引格式")
+	}
+
+	return live2dAssets, nil
+}
+
+// getLive2dAssets 获取 Live2D 资源映射
+// 参数:
+//   - ctx: 上下文
+//
+// 返回:
+//   - map[string]string: Live2D 资源及所属服务器
+//   - error: 错误信息
+func (c *Client) getLive2dAssets(ctx context.Context) (map[string]string, error) {
+	live2dAssets := make(map[string]string)
+
+	for tag, s := range c.assetServers {
+		newLive2dAssets, err := c.getSingleLive2dAssets(ctx, tag, &s)
+		if err != nil {
+			return nil, err
+		}
+
+		for costume := range newLive2dAssets {
+			if _, o := live2dAssets[costume]; !o {
+				live2dAssets[costume] = tag
+			}
+		}
 	}
 
 	return live2dAssets, nil
@@ -193,28 +222,34 @@ func (c *Client) getLive2dAssets(ctx context.Context) (map[string]any, error) {
 // 返回:
 //   - []string: 服装列表（按特定规则排序）
 //   - error: 错误信息
-func (c *Client) GetCharaCostumes(ctx context.Context, charaID int) ([]string, error) {
+func (c *Client) GetCharaCostumes(ctx context.Context, charaID int) ([]model.Live2dAsset, error) {
 	live2dAssets, err := c.getLive2dAssets(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var costumes []string
-	for live2d := range live2dAssets {
-		if live2d[:3] == fmt.Sprintf("%03d", charaID) && !strings.HasSuffix(live2d, "general") {
-			costumes = append(costumes, live2d)
+	var costumes []model.Live2dAsset
+	for costume, server := range live2dAssets {
+		// exist := costume[:3] == fmt.Sprintf("%03d", charaID) // example: bili_001_collabo_r
+		exist := strings.Contains(costume, fmt.Sprintf("%03d", charaID))
+
+		if exist && !strings.HasSuffix(costume, "general") {
+			costumes = append(costumes, model.Live2dAsset{
+				Server:  server,
+				Costume: costume,
+			})
 		}
 	}
 
 	// 对服装列表进行排序
 	sort.Slice(costumes, func(i, j int) bool {
 		// 提取服装ID（模型名称中的数字部分）
-		iParts := strings.Split(costumes[i], "_")
-		jParts := strings.Split(costumes[j], "_")
+		iParts := strings.Split(costumes[i].Costume, "_")
+		jParts := strings.Split(costumes[j].Costume, "_")
 
 		// 如果包含"live_event"，将其排在后面
-		iHasEvent := strings.Contains(costumes[i], "live_event")
-		jHasEvent := strings.Contains(costumes[j], "live_event")
+		iHasEvent := strings.Contains(costumes[i].Costume, "live_event")
+		jHasEvent := strings.Contains(costumes[j].Costume, "live_event")
 
 		if iHasEvent != jHasEvent {
 			return !iHasEvent
@@ -230,7 +265,7 @@ func (c *Client) GetCharaCostumes(ctx context.Context, charaID int) ([]string, e
 		}
 
 		// 如果无法比较ID，则按字符串排序
-		return costumes[i] < costumes[j]
+		return costumes[i].Costume < costumes[j].Costume
 	})
 
 	return costumes, nil
@@ -239,42 +274,49 @@ func (c *Client) GetCharaCostumes(ctx context.Context, charaID int) ([]string, e
 // GetLive2dData 获取指定 Live2D 模型的构建数据
 // 参数:
 //   - ctx: 上下文
-//   - live2dName: Live2D 模型名称
+//   - live2d: Live2D 资源
 //
 // 返回:
+//   - *config.AssetServerConfig: 模型所属 Bestdori 服务器 API 信息
 //   - *model.BuildData: Live2D 构建数据
 //   - error: 错误信息
-func (c *Client) GetLive2dData(ctx context.Context, live2dName string) (*model.BuildData, error) {
+func (c *Client) GetLive2dData(ctx context.Context, live2d *model.Live2dAsset) (*config.AssetServerConfig, *model.BuildData, error) {
+	// 获取模型所属服务器的配置
+	s, o := c.assetServers[live2d.Server]
+	if !o {
+		return nil, nil, fmt.Errorf("不存在的服务器来源: %s", live2d.Server)
+	}
+
 	// 构建资源包 URL
-	url := fmt.Sprintf("%s/live2d/chara/%s_rip/buildData.asset", c.baseAssetsURL, live2dName)
-	log.DefaultLogger.Info().Str("live2dName", live2dName).Str("url", url).Msg("开始获取Live2D构建数据")
+	url := fmt.Sprintf("%s/live2d/chara/%s_rip/buildData.asset", s.BaseAssetsURL, live2d.Costume)
+	log.DefaultLogger.Info().Str("live2dName", live2d.Costume).Str("url", url).Msg("开始获取Live2D构建数据")
 
 	// 获取构建数据
 	data, err := c.FetchData(ctx, url, "")
 	if err != nil {
-		log.DefaultLogger.Error().Str("live2dName", live2dName).Err(err).Msg("获取构建数据失败")
-		return nil, fmt.Errorf("获取构建数据失败: %w", err)
+		log.DefaultLogger.Error().Str("live2dName", live2d.Costume).Err(err).Msg("获取构建数据失败")
+		return nil, nil, fmt.Errorf("获取构建数据失败: %w", err)
 	}
 
 	// 提取基础数据
 	baseData, ok := data["Base"].(map[string]any)
 	if !ok {
-		log.DefaultLogger.Error().Str("live2dName", live2dName).Msg("构建数据格式错误: 缺少 Base 字段")
-		return nil, errors.New("构建数据格式错误: 缺少 Base 字段")
+		log.DefaultLogger.Error().Str("live2dName", live2d.Costume).Msg("构建数据格式错误: 缺少 Base 字段")
+		return nil, nil, errors.New("构建数据格式错误: 缺少 Base 字段")
 	}
 
 	// 序列化基础数据
 	jsonData, err := json.Marshal(baseData)
 	if err != nil {
-		log.DefaultLogger.Error().Str("live2dName", live2dName).Err(err).Msg("序列化构建数据失败")
-		return nil, fmt.Errorf("序列化构建数据失败: %w", err)
+		log.DefaultLogger.Error().Str("live2dName", live2d.Costume).Err(err).Msg("序列化构建数据失败")
+		return nil, nil, fmt.Errorf("序列化构建数据失败: %w", err)
 	}
 
 	// 反序列化为 BuildData 结构
 	var buildData model.BuildData
 	if unmarshalErr := json.Unmarshal(jsonData, &buildData); unmarshalErr != nil {
-		log.DefaultLogger.Error().Str("live2dName", live2dName).Err(unmarshalErr).Msg("反序列化构建数据失败")
-		return nil, fmt.Errorf("反序列化构建数据失败: %w", unmarshalErr)
+		log.DefaultLogger.Error().Str("live2dName", live2d.Costume).Err(unmarshalErr).Msg("反序列化构建数据失败")
+		return nil, nil, fmt.Errorf("反序列化构建数据失败: %w", unmarshalErr)
 	}
 
 	// 处理 model 和 motions 文件的 .bytes 后缀
@@ -288,8 +330,8 @@ func (c *Client) GetLive2dData(ctx context.Context, live2dName string) (*model.B
 		buildData.Textures[i].EnsurePngSuffix()
 	}
 
-	log.DefaultLogger.Info().Str("live2dName", live2dName).Msg("Live2D构建数据处理完成")
-	return &buildData, nil
+	log.DefaultLogger.Info().Str("live2dName", live2d.Costume).Msg("Live2D构建数据处理完成")
+	return &s, &buildData, nil
 }
 
 // ValidateLive2dModel 验证指定的 Live2D 模型是否存在
@@ -323,4 +365,11 @@ func (c *Client) SetCharaCachePath(path string) {
 //   - use: 是否使用缓存
 func (c *Client) SetUseCharaCache(use bool) {
 	c.useCharaCache = use
+}
+
+// GetDefaultAssetServer 获取默认 Bestdori 服务器标签
+// 返回:
+//   - string: 默认 Bestdori 服务器标签
+func (c *Client) GetDefaultAssetServer() string {
+	return c.defaultAssetServer
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -330,6 +330,35 @@ func (c *Client) GetLive2dData(
 	return &s, &buildData, nil
 }
 
+// GetLive2dAsset 获取指定模型所属的资源信息
+// 参数:
+//   - ctx: 上下文
+//   - live2dName: Live2D 模型名称
+//
+// 返回:
+//   - *model.Live2dAsset: 模型资源信息
+//   - bool: 模型是否存在
+//   - error: 错误信息
+func (c *Client) GetLive2dAsset(
+	ctx context.Context,
+	live2dName string,
+) (*model.Live2dAsset, bool, error) {
+	live2dAssets, err := c.getLive2dAssets(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("获取资源索引失败: %w", err)
+	}
+
+	server, exists := live2dAssets[live2dName]
+	if !exists {
+		return nil, false, nil
+	}
+
+	return &model.Live2dAsset{
+		Server:  server,
+		Costume: live2dName,
+	}, true, nil
+}
+
 // ValidateLive2dModel 验证指定的 Live2D 模型是否存在
 // 参数:
 //   - ctx: 上下文
@@ -339,13 +368,11 @@ func (c *Client) GetLive2dData(
 //   - bool: 模型是否存在
 //   - error: 错误信息
 func (c *Client) ValidateLive2dModel(ctx context.Context, live2dName string) (bool, error) {
-	live2dAssets, err := c.getLive2dAssets(ctx)
+	_, exists, err := c.GetLive2dAsset(ctx, live2dName)
 	if err != nil {
-		return false, fmt.Errorf("获取资源索引失败: %w", err)
+		return false, err
 	}
 
-	// 检查模型名是否存在于live2dAssets中
-	_, exists := live2dAssets[live2dName]
 	return exists, nil
 }
 

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -231,7 +231,12 @@ func isCharaCostume(costume string, charaID int) bool {
 		return false
 	}
 
-	return parts[0] == fmt.Sprintf("%03d", charaID)
+	idStr := fmt.Sprintf("%03d", charaID)
+	if parts[0] == idStr {
+		return true
+	}
+
+	return len(parts) >= 3 && parts[0] == "bili" && parts[1] == idStr
 }
 
 // GetCharaCostumes 获取指定角色的所有 Live2D 服装列表

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -26,6 +26,7 @@ type Client struct {
 	charaCachePath string                              // 角色信息缓存路径
 	cacheDuration  time.Duration                       // 缓存过期时间
 	charaRosterURL string                              // 角色信息 API URL
+	defaultServer  string                              // 默认 Bestdori 资源服务器标签
 	serverTags     []string                            // Bestdori 资源服务器标签 (有序)
 	assetServers   map[string]config.AssetServerConfig // Bestdori 资源服务器配置
 	httpClient     *http.Client                        // HTTP 客户端
@@ -42,6 +43,7 @@ func NewClient() *Client {
 		charaCachePath: cfg.CharaCachePath,
 		cacheDuration:  cfg.CacheDuration,
 		charaRosterURL: cfg.CharaRosterURL,
+		defaultServer:  cfg.DefaultAssetServer,
 		serverTags:     cfg.ServerTags,
 		assetServers:   cfg.AssetServers,
 		httpClient: &http.Client{
@@ -394,5 +396,9 @@ func (c *Client) SetUseCharaCache(use bool) {
 // 返回:
 //   - string: 默认 Bestdori 服务器标签
 func (c *Client) GetDefaultAssetServer() string {
+	if c.defaultServer != "" {
+		return c.defaultServer
+	}
+
 	return c.serverTags[0]
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -23,13 +23,13 @@ import (
 // Client 表示 API 客户端
 // 负责处理与 Bestdori API 的所有交互.
 type Client struct {
-	useCharaCache      bool                                // 是否使用角色信息缓存
-	charaCachePath     string                              // 角色信息缓存路径
-	cacheDuration      time.Duration                       // 缓存过期时间
-	charaRosterURL     string                              // 角色信息 API URL
-	defaultAssetServer string                              // 默认 Bestdori 资源服务器标签
-	assetServers       map[string]config.AssetServerConfig // Bestdori 资源服务器配置
-	httpClient         *http.Client                        // HTTP 客户端
+	useCharaCache  bool                                // 是否使用角色信息缓存
+	charaCachePath string                              // 角色信息缓存路径
+	cacheDuration  time.Duration                       // 缓存过期时间
+	charaRosterURL string                              // 角色信息 API URL
+	serverTags     []string                            // Bestdori 资源服务器标签 (有序)
+	assetServers   map[string]config.AssetServerConfig // Bestdori 资源服务器配置
+	httpClient     *http.Client                        // HTTP 客户端
 }
 
 // NewClient 创建新的 API 客户端实例
@@ -39,12 +39,12 @@ func NewClient() *Client {
 	cfg := config.Get()
 	// s, _ := cfg.AssetServers[cfg.DefaultAssetServer]
 	return &Client{
-		useCharaCache:      cfg.UseCharaCache,
-		charaCachePath:     cfg.CharaCachePath,
-		cacheDuration:      cfg.CacheDuration,
-		charaRosterURL:     cfg.CharaRosterURL,
-		defaultAssetServer: cfg.DefaultAssetServer,
-		assetServers:       cfg.AssetServers,
+		useCharaCache:  cfg.UseCharaCache,
+		charaCachePath: cfg.CharaCachePath,
+		cacheDuration:  cfg.CacheDuration,
+		charaRosterURL: cfg.CharaRosterURL,
+		serverTags:     cfg.ServerTags,
+		assetServers:   cfg.AssetServers,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
@@ -202,7 +202,12 @@ func (c *Client) getSingleLive2dAssets(
 func (c *Client) getLive2dAssets(ctx context.Context) (map[string]string, error) {
 	live2dAssets := make(map[string]string)
 
-	for tag, s := range c.assetServers {
+	for _, tag := range c.serverTags { // 有序
+		s, o := c.assetServers[tag]
+		if !o {
+			return nil, fmt.Errorf("未定义的 Bestdori 服务器标签: %s", s)
+		}
+
 		newLive2dAssets, err := c.getSingleLive2dAssets(ctx, tag, &s)
 		if err != nil {
 			return nil, err
@@ -388,5 +393,5 @@ func (c *Client) SetUseCharaCache(use bool) {
 // 返回:
 //   - string: 默认 Bestdori 服务器标签
 func (c *Client) GetDefaultAssetServer() string {
-	return c.defaultAssetServer
+	return c.serverTags[0]
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -242,7 +242,7 @@ func (c *Client) GetCharaCostumes(ctx context.Context, charaID int) ([]model.Liv
 		// 仅在名称按 '_' 分段且存在完整的 %03d 段且该段不是最后一段时视为存在
 		exist := false
 		parts := strings.Split(costume, "_")
-		if len(parts) >= 3 {
+		if len(parts) >= 2 {
 			idStr := fmt.Sprintf("%03d", charaID)
 			for idx, p := range parts {
 				if p == idStr && idx < len(parts)-1 {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -174,7 +174,11 @@ func (c *Client) GetChara(ctx context.Context, charaID int) (map[string]any, err
 // 返回:
 //   - map[string]any: Live2D 资源映射
 //   - error: 错误信息
-func (c *Client) getSingleLive2dAssets(ctx context.Context, tag string, s *config.AssetServerConfig) (map[string]any, error) {
+func (c *Client) getSingleLive2dAssets(
+	ctx context.Context,
+	tag string,
+	s *config.AssetServerConfig,
+) (map[string]any, error) {
 	assetsInfo, err := c.FetchData(ctx, s.AssetsIndexURL, fmt.Sprintf("assets_info_%s.json", tag))
 	if err != nil {
 		return nil, err
@@ -230,8 +234,18 @@ func (c *Client) GetCharaCostumes(ctx context.Context, charaID int) ([]model.Liv
 
 	var costumes []model.Live2dAsset
 	for costume, server := range live2dAssets {
-		// exist := costume[:3] == fmt.Sprintf("%03d", charaID) // example: bili_001_collabo_r
-		exist := strings.Contains(costume, fmt.Sprintf("%03d", charaID))
+		// 仅在名称按 '_' 分段且存在完整的 %03d 段且该段不是最后一段时视为存在
+		exist := false
+		parts := strings.Split(costume, "_")
+		if len(parts) >= 3 {
+			idStr := fmt.Sprintf("%03d", charaID)
+			for idx, p := range parts {
+				if p == idStr && idx < len(parts)-1 {
+					exist = true
+					break
+				}
+			}
+		}
 
 		if exist && !strings.HasSuffix(costume, "general") {
 			costumes = append(costumes, model.Live2dAsset{
@@ -280,7 +294,10 @@ func (c *Client) GetCharaCostumes(ctx context.Context, charaID int) ([]model.Liv
 //   - *config.AssetServerConfig: 模型所属 Bestdori 服务器 API 信息
 //   - *model.BuildData: Live2D 构建数据
 //   - error: 错误信息
-func (c *Client) GetLive2dData(ctx context.Context, live2d *model.Live2dAsset) (*config.AssetServerConfig, *model.BuildData, error) {
+func (c *Client) GetLive2dData(
+	ctx context.Context,
+	live2d *model.Live2dAsset,
+) (*config.AssetServerConfig, *model.BuildData, error) {
 	// 获取模型所属服务器的配置
 	s, o := c.assetServers[live2d.Server]
 	if !o {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -223,6 +223,15 @@ func (c *Client) getLive2dAssets(ctx context.Context) (map[string]string, error)
 	return live2dAssets, nil
 }
 
+func isCharaCostume(costume string, charaID int) bool {
+	parts := strings.Split(costume, "_")
+	if len(parts) < 2 {
+		return false
+	}
+
+	return parts[0] == fmt.Sprintf("%03d", charaID)
+}
+
 // GetCharaCostumes 获取指定角色的所有 Live2D 服装列表
 // 参数:
 //   - ctx: 上下文
@@ -239,20 +248,7 @@ func (c *Client) GetCharaCostumes(ctx context.Context, charaID int) ([]model.Liv
 
 	var costumes []model.Live2dAsset
 	for costume, server := range live2dAssets {
-		// 仅在名称按 '_' 分段且存在完整的 %03d 段且该段不是最后一段时视为存在
-		exist := false
-		parts := strings.Split(costume, "_")
-		if len(parts) >= 2 {
-			idStr := fmt.Sprintf("%03d", charaID)
-			for idx, p := range parts {
-				if p == idStr && idx < len(parts)-1 {
-					exist = true
-					break
-				}
-			}
-		}
-
-		if exist && !strings.HasSuffix(costume, "general") {
+		if isCharaCostume(costume, charaID) && !strings.HasSuffix(costume, "general") {
 			costumes = append(costumes, model.Live2dAsset{
 				Server:  server,
 				Costume: costume,

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -320,3 +320,18 @@ func TestGetLive2dAssetReturnsSourceServer(t *testing.T) {
 	require.Equal(t, "cn", asset.Server)
 	require.Equal(t, "037_casual-2023", asset.Costume)
 }
+
+func TestGetDefaultAssetServerHonorsConfigDefault(t *testing.T) {
+	config.Init()
+	cfg := config.Get()
+	cfg.DefaultAssetServer = "cn"
+	cfg.ServerTags = []string{"jp", "cn"}
+	cfg.AssetServers = map[string]config.AssetServerConfig{
+		"jp": config.DefaultAssetServerConfigTemplate("jp"),
+		"cn": config.DefaultAssetServerConfigTemplate("cn"),
+	}
+
+	client := api.NewClient()
+
+	require.Equal(t, "cn", client.GetDefaultAssetServer())
+}

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -303,3 +303,20 @@ func TestGetCharaCostumesMatchesLeadingCharaIDOnly(t *testing.T) {
 	require.Len(t, costumes, 1)
 	require.Equal(t, "102_school", costumes[0].Costume)
 }
+
+func TestGetLive2dAssetReturnsSourceServer(t *testing.T) {
+	client := setupLive2dAssetsTestClient(t, map[string]map[string]any{
+		"jp": {},
+		"cn": {
+			"037_casual-2023": map[string]any{},
+		},
+	})
+
+	asset, exists, err := client.GetLive2dAsset(context.Background(), "037_casual-2023")
+
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.NotNil(t, asset)
+	require.Equal(t, "cn", asset.Server)
+	require.Equal(t, "037_casual-2023", asset.Costume)
+}

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -2,7 +2,10 @@ package api_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +15,51 @@ import (
 	"github.com/A-kirami/bestdori-live2d-downloader/pkg/log"
 	"github.com/stretchr/testify/require"
 )
+
+func setupLive2dAssetsTestClient(
+	t *testing.T,
+	assetServers map[string]map[string]any,
+) *api.Client {
+	t.Helper()
+
+	config.Init()
+	cfg := config.Get()
+	cfg.ServerTags = make([]string, 0, len(assetServers))
+	cfg.AssetServers = make(map[string]config.AssetServerConfig, len(assetServers))
+
+	mux := http.NewServeMux()
+	for tag, costumes := range assetServers {
+		cfg.ServerTags = append(cfg.ServerTags, tag)
+		cfg.AssetServers[tag] = config.AssetServerConfig{
+			BaseAssetsURL:  "https://example.invalid/assets/" + tag,
+			AssetsIndexURL: "http://example.invalid/" + tag + "/assets/_info.json",
+		}
+
+		response := map[string]any{
+			"live2d": map[string]any{
+				"chara": costumes,
+			},
+		}
+
+		path := "/" + tag + "/assets/_info.json"
+		mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(response))
+		})
+	}
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	for tag, serverCfg := range cfg.AssetServers {
+		serverCfg.AssetsIndexURL = server.URL + "/" + tag + "/assets/_info.json"
+		cfg.AssetServers[tag] = serverCfg
+	}
+
+	client := api.NewClient()
+	client.SetUseCharaCache(false)
+	client.SetCharaCachePath(t.TempDir())
+	return client
+}
 
 // setupTest 设置测试环境.
 func setupTest(t *testing.T) {
@@ -222,4 +270,21 @@ func TestValidateLive2dModel(t *testing.T) {
 			require.Equal(t, tt.wantExists, exists, "ValidateLive2dModel() should return correct existence status")
 		})
 	}
+}
+
+func TestGetCharaCostumesIncludesTwoPartCostumes(t *testing.T) {
+	client := setupLive2dAssetsTestClient(t, map[string]map[string]any{
+		"jp": {
+			"001_arbeit":      map[string]any{},
+			"001_live_default": map[string]any{},
+			"002_cafe":        map[string]any{},
+		},
+	})
+
+	costumes, err := client.GetCharaCostumes(context.Background(), 1)
+
+	require.NoError(t, err)
+	require.Len(t, costumes, 2)
+	require.Equal(t, "001_arbeit", costumes[0].Costume)
+	require.Equal(t, "001_live_default", costumes[1].Costume)
 }

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -317,8 +317,8 @@ func TestGetCharaCostumesIncludesBiliSpecialCostumes(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, costumes, 2)
-	require.Equal(t, "001_school", costumes[0].Costume)
-	require.Equal(t, "bili_001_collabo_r", costumes[1].Costume)
+	require.Equal(t, "bili_001_collabo_r", costumes[0].Costume)
+	require.Equal(t, "001_school", costumes[1].Costume)
 }
 
 func TestGetCharaCostumesIgnoresUnsupportedBilPrefix(t *testing.T) {

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -304,6 +304,38 @@ func TestGetCharaCostumesMatchesLeadingCharaIDOnly(t *testing.T) {
 	require.Equal(t, "102_school", costumes[0].Costume)
 }
 
+func TestGetCharaCostumesIncludesBiliSpecialCostumes(t *testing.T) {
+	client := setupLive2dAssetsTestClient(t, map[string]map[string]any{
+		"jp": {
+			"001_school":          map[string]any{},
+			"bili_001_collabo_r":  map[string]any{},
+			"bili_002_collabo_ssr": map[string]any{},
+		},
+	})
+
+	costumes, err := client.GetCharaCostumes(context.Background(), 1)
+
+	require.NoError(t, err)
+	require.Len(t, costumes, 2)
+	require.Equal(t, "001_school", costumes[0].Costume)
+	require.Equal(t, "bili_001_collabo_r", costumes[1].Costume)
+}
+
+func TestGetCharaCostumesIgnoresUnsupportedBilPrefix(t *testing.T) {
+	client := setupLive2dAssetsTestClient(t, map[string]map[string]any{
+		"jp": {
+			"001_school":          map[string]any{},
+			"bil_001_collabo_ssr": map[string]any{},
+		},
+	})
+
+	costumes, err := client.GetCharaCostumes(context.Background(), 1)
+
+	require.NoError(t, err)
+	require.Len(t, costumes, 1)
+	require.Equal(t, "001_school", costumes[0].Costume)
+}
+
 func TestGetLive2dAssetReturnsSourceServer(t *testing.T) {
 	client := setupLive2dAssetsTestClient(t, map[string]map[string]any{
 		"jp": {},

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -43,7 +43,9 @@ func setupLive2dAssetsTestClient(
 
 		path := "/" + tag + "/assets/_info.json"
 		mux.HandleFunc(path, func(w http.ResponseWriter, _ *http.Request) {
-			require.NoError(t, json.NewEncoder(w).Encode(response))
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				t.Errorf("encode %s response: %v", path, err)
+			}
 		})
 	}
 
@@ -275,9 +277,9 @@ func TestValidateLive2dModel(t *testing.T) {
 func TestGetCharaCostumesIncludesTwoPartCostumes(t *testing.T) {
 	client := setupLive2dAssetsTestClient(t, map[string]map[string]any{
 		"jp": {
-			"001_arbeit":      map[string]any{},
+			"001_arbeit":       map[string]any{},
 			"001_live_default": map[string]any{},
-			"002_cafe":        map[string]any{},
+			"002_cafe":         map[string]any{},
 		},
 	})
 
@@ -307,8 +309,8 @@ func TestGetCharaCostumesMatchesLeadingCharaIDOnly(t *testing.T) {
 func TestGetCharaCostumesIncludesBiliSpecialCostumes(t *testing.T) {
 	client := setupLive2dAssetsTestClient(t, map[string]map[string]any{
 		"jp": {
-			"001_school":          map[string]any{},
-			"bili_001_collabo_r":  map[string]any{},
+			"001_school":           map[string]any{},
+			"bili_001_collabo_r":   map[string]any{},
 			"bili_002_collabo_ssr": map[string]any{},
 		},
 	})

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -288,3 +288,18 @@ func TestGetCharaCostumesIncludesTwoPartCostumes(t *testing.T) {
 	require.Equal(t, "001_arbeit", costumes[0].Costume)
 	require.Equal(t, "001_live_default", costumes[1].Costume)
 }
+
+func TestGetCharaCostumesMatchesLeadingCharaIDOnly(t *testing.T) {
+	client := setupLive2dAssetsTestClient(t, map[string]map[string]any{
+		"jp": {
+			"001_event_102_story_01": map[string]any{},
+			"102_school":             map[string]any{},
+		},
+	})
+
+	costumes, err := client.GetCharaCostumes(context.Background(), 102)
+
+	require.NoError(t, err)
+	require.Len(t, costumes, 1)
+	require.Equal(t, "102_school", costumes[0].Costume)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,7 +1,17 @@
 // Package config 提供了程序的配置管理功能
 package config
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
+
+// AssetServerConfig 表示 Bestdori 资源服务器配置.
+type AssetServerConfig struct {
+	// API 配置
+	BaseAssetsURL  string // Bestdori 资源基础 URL
+	AssetsIndexURL string // 资源索引 API URL
+}
 
 // Config 表示程序的配置结构.
 type Config struct {
@@ -15,9 +25,9 @@ type Config struct {
 	CacheDuration time.Duration // 缓存过期时间
 
 	// API 配置
-	BaseAssetsURL  string // Bestdori 资源基础 URL
-	CharaRosterURL string // 角色信息 API URL
-	AssetsIndexURL string // 资源索引 API URL
+	CharaRosterURL     string                       // 角色信息 API URL
+	DefaultAssetServer string                       // 默认 Bestdori 资源服务器标签
+	AssetServers       map[string]AssetServerConfig // Bestdori 资源服务器
 
 	// 下载配置
 	MaxConcurrentDownloads int // 单个模型下载时的最大并发文件下载数
@@ -29,6 +39,26 @@ var (
 	//nolint:gochecknoglobals // 使用全局配置实例是必要的，因为需要在程序的不同部分访问相同的配置
 	globalConfig *Config
 )
+
+func DefaultAssetServers() []string {
+	return []string{"jp", "cn", "en", "kr", "tw"}
+}
+
+func DefaultAssetServerConfigTemplate(s string) AssetServerConfig {
+	return AssetServerConfig{
+		BaseAssetsURL:  fmt.Sprintf("https://bestdori.com/assets/%s", s),
+		AssetsIndexURL: fmt.Sprintf("https://bestdori.com/api/explorer/%s/assets/_info.json", s),
+	}
+}
+
+// DefaultAssetServersConfig 返回默认 Bestdori 资源服务器配置
+func DefaultAssetServersConfig() map[string]AssetServerConfig {
+	serverConfigs := make(map[string]AssetServerConfig)
+	for _, s := range DefaultAssetServers() {
+		serverConfigs[s] = DefaultAssetServerConfigTemplate(s)
+	}
+	return serverConfigs
+}
 
 // DefaultConfig 返回默认配置.
 func DefaultConfig() *Config {
@@ -43,9 +73,9 @@ func DefaultConfig() *Config {
 		CacheDuration: 24 * time.Hour,
 
 		// API 配置
-		BaseAssetsURL:  "https://bestdori.com/assets/jp",
-		CharaRosterURL: "https://bestdori.com/api/characters",
-		AssetsIndexURL: "https://bestdori.com/api/explorer/jp/assets/_info.json",
+		CharaRosterURL:     "https://bestdori.com/api/characters",
+		DefaultAssetServer: DefaultAssetServers()[0],
+		AssetServers:       DefaultAssetServersConfig(),
 
 		// 下载配置
 		MaxConcurrentDownloads: 20,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,7 +51,7 @@ func DefaultAssetServerConfigTemplate(s string) AssetServerConfig {
 	}
 }
 
-// DefaultAssetServersConfig 返回默认 Bestdori 资源服务器配置
+// DefaultAssetServersConfig 返回默认 Bestdori 资源服务器配置.
 func DefaultAssetServersConfig() map[string]AssetServerConfig {
 	serverConfigs := make(map[string]AssetServerConfig)
 	for _, s := range DefaultAssetServers() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,8 +25,10 @@ type Config struct {
 	CacheDuration time.Duration // 缓存过期时间
 
 	// API 配置
-	CharaRosterURL     string                       // 角色信息 API URL
-	DefaultAssetServer string                       // 默认 Bestdori 资源服务器标签
+	CharaRosterURL string // 角色信息 API URL
+	// DefaultAssetServer 指定默认使用的资源服务器（例如 "jp"）
+	DefaultAssetServer string
+	ServerTags         []string                     // Bestdori 资源服务器标签 (有序)
 	AssetServers       map[string]AssetServerConfig // Bestdori 资源服务器
 
 	// 下载配置
@@ -74,7 +76,8 @@ func DefaultConfig() *Config {
 
 		// API 配置
 		CharaRosterURL:     "https://bestdori.com/api/characters",
-		DefaultAssetServer: DefaultAssetServers()[0],
+		DefaultAssetServer: "jp",
+		ServerTags:         DefaultAssetServers(),
 		AssetServers:       DefaultAssetServersConfig(),
 
 		// 下载配置

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,12 +24,13 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 24*time.Hour, cfg.CacheDuration, "CacheDuration should be correct")
 
 	// 测试 API 配置
-	assert.Equal(t, "https://bestdori.com/assets/jp", cfg.BaseAssetsURL, "BaseAssetsURL should be correct")
+	assetServer := cfg.AssetServers[cfg.DefaultAssetServer]
+	assert.Equal(t, "https://bestdori.com/assets/jp", assetServer.BaseAssetsURL, "BaseAssetsURL should be correct")
 	assert.Equal(t, "https://bestdori.com/api/characters", cfg.CharaRosterURL, "CharaRosterURL should be correct")
 	assert.Equal(
 		t,
 		"https://bestdori.com/api/explorer/jp/assets/_info.json",
-		cfg.AssetsIndexURL,
+		assetServer.AssetsIndexURL,
 		"AssetsIndexURL should be correct",
 	)
 
@@ -53,9 +54,11 @@ func TestInit(t *testing.T) {
 	assert.Equal(t, defaultCfg.LogPath, cfg.LogPath, "LogPath should match default")
 	assert.Equal(t, defaultCfg.UseCharaCache, cfg.UseCharaCache, "UseCharaCache should match default")
 	assert.Equal(t, defaultCfg.CacheDuration, cfg.CacheDuration, "CacheDuration should match default")
-	assert.Equal(t, defaultCfg.BaseAssetsURL, cfg.BaseAssetsURL, "BaseAssetsURL should match default")
+	defAssetServer := defaultCfg.AssetServers[defaultCfg.DefaultAssetServer]
+	curAssetServer := cfg.AssetServers[cfg.DefaultAssetServer]
+	assert.Equal(t, defAssetServer.BaseAssetsURL, curAssetServer.BaseAssetsURL, "BaseAssetsURL should match default")
 	assert.Equal(t, defaultCfg.CharaRosterURL, cfg.CharaRosterURL, "CharaRosterURL should match default")
-	assert.Equal(t, defaultCfg.AssetsIndexURL, cfg.AssetsIndexURL, "AssetsIndexURL should match default")
+	assert.Equal(t, defAssetServer.AssetsIndexURL, curAssetServer.AssetsIndexURL, "AssetsIndexURL should match default")
 	assert.Equal(
 		t,
 		defaultCfg.MaxConcurrentDownloads,
@@ -68,9 +71,10 @@ func TestInit(t *testing.T) {
 func TestGet(t *testing.T) {
 	cfg := config.Get()
 	assert.NotNil(t, cfg, "Get() should not return nil")
-	assert.NotEmpty(t, cfg.BaseAssetsURL, "BaseAssetsURL should not be empty")
+	assetServer := cfg.AssetServers[cfg.DefaultAssetServer]
+	assert.NotEmpty(t, assetServer.BaseAssetsURL, "BaseAssetsURL should not be empty")
 	assert.NotEmpty(t, cfg.CharaRosterURL, "CharaRosterURL should not be empty")
-	assert.NotEmpty(t, cfg.AssetsIndexURL, "AssetsIndexURL should not be empty")
+	assert.NotEmpty(t, assetServer.AssetsIndexURL, "AssetsIndexURL should not be empty")
 	assert.NotEmpty(t, cfg.Live2dSavePath, "Live2dSavePath should not be empty")
 	assert.NotEmpty(t, cfg.CharaCachePath, "CharaCachePath should not be empty")
 	assert.Positive(t, cfg.CacheDuration, "CacheDuration should be greater than 0")

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -206,6 +206,7 @@ func (d *Downloader) DownloadBundleFile(
 	}
 
 	// 执行请求
+	// #nosec G704 -- 请求的 URL 源自受控的服务器配置或构建逻辑，已在调用方/配置中受限
 	resp, err := d.httpClient.Do(req)
 	if err != nil {
 		log.DefaultLogger.Error().Str("url", req.URL.String()).Err(err).Msg("下载文件失败")

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -85,7 +85,11 @@ func NewDownloader(apiClient *api.Client, tuiModel *tui.Model, program *tea.Prog
 // 返回:
 //   - *http.Request: HTTP请求
 //   - error: 错误信息
-func (d *Downloader) createDownloadRequest(ctx context.Context, s *config.AssetServerConfig, bundleFile model.BundleFile) (*http.Request, error) {
+func (d *Downloader) createDownloadRequest(
+	ctx context.Context,
+	s *config.AssetServerConfig,
+	bundleFile model.BundleFile,
+) (*http.Request, error) {
 	url := fmt.Sprintf("%s/%s_rip/%s", s.BaseAssetsURL, bundleFile.BundleName, bundleFile.FileName)
 	log.DefaultLogger.Info().Str("url", url).Msg("开始下载文件")
 
@@ -292,7 +296,13 @@ func (b *Live2dBuilder) ProcessFile(
 	allowNotFound bool,
 ) (string, error) {
 	if _, statErr := os.Stat(filePath); os.IsNotExist(statErr) {
-		if downloadErr := b.downloader.DownloadBundleFile(ctx, b.server, bundleFile, filePath, allowNotFound); downloadErr != nil {
+		if downloadErr := b.downloader.DownloadBundleFile(
+			ctx,
+			b.server,
+			bundleFile,
+			filePath,
+			allowNotFound,
+		); downloadErr != nil {
 			return "", fmt.Errorf("下载文件失败: %w", downloadErr)
 		}
 	}
@@ -528,7 +538,13 @@ func (b *Live2dBuilder) startWorkerPool(ctx context.Context, taskChan chan downl
 					errorChan <- errors.New("下载已取消")
 					return
 				default:
-					if downloadErr := b.downloader.DownloadBundleFile(ctx, b.server, task.bundleFile, task.filePath, task.allowNotFound); downloadErr != nil {
+					if downloadErr := b.downloader.DownloadBundleFile(
+						ctx,
+						b.server,
+						task.bundleFile,
+						task.filePath,
+						task.allowNotFound,
+					); downloadErr != nil {
 						task.result <- downloadResult{err: fmt.Errorf("下载文件失败: %w", downloadErr)}
 						continue
 					}

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -79,13 +79,14 @@ func NewDownloader(apiClient *api.Client, tuiModel *tui.Model, program *tea.Prog
 // createDownloadRequest 创建下载请求
 // 参数:
 //   - ctx: 上下文
+//   - s: Bestdori 服务器配置
 //   - bundleFile: 资源包文件信息
 //
 // 返回:
 //   - *http.Request: HTTP请求
 //   - error: 错误信息
-func (d *Downloader) createDownloadRequest(ctx context.Context, bundleFile model.BundleFile) (*http.Request, error) {
-	url := fmt.Sprintf("%s/%s_rip/%s", config.Get().BaseAssetsURL, bundleFile.BundleName, bundleFile.FileName)
+func (d *Downloader) createDownloadRequest(ctx context.Context, s *config.AssetServerConfig, bundleFile model.BundleFile) (*http.Request, error) {
+	url := fmt.Sprintf("%s/%s_rip/%s", s.BaseAssetsURL, bundleFile.BundleName, bundleFile.FileName)
 	log.DefaultLogger.Info().Str("url", url).Msg("开始下载文件")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -173,6 +174,7 @@ func (d *Downloader) writeFileContent(file *os.File, resp *http.Response, filePa
 // DownloadBundleFile 下载资源包文件
 // 参数:
 //   - ctx: 上下文
+//   - s: Bestdori 服务器配置
 //   - bundleFile: 资源包文件信息
 //   - filePath: 保存路径
 //   - allowNotFound: 是否允许文件不存在（404错误时视为正常情况）
@@ -181,6 +183,7 @@ func (d *Downloader) writeFileContent(file *os.File, resp *http.Response, filePa
 //   - error: 错误信息
 func (d *Downloader) DownloadBundleFile(
 	ctx context.Context,
+	s *config.AssetServerConfig,
 	bundleFile model.BundleFile,
 	filePath string,
 	allowNotFound bool,
@@ -193,7 +196,7 @@ func (d *Downloader) DownloadBundleFile(
 	}
 
 	// 创建请求
-	req, err := d.createDownloadRequest(ctx, bundleFile)
+	req, err := d.createDownloadRequest(ctx, s, bundleFile)
 	if err != nil {
 		return err
 	}
@@ -235,17 +238,19 @@ func (d *Downloader) DownloadBundleFile(
 // Live2dBuilder 表示 Live2D 构建器
 // 负责构建完整的 Live2D 模型，包括下载所有必要文件.
 type Live2dBuilder struct {
-	path       string             // 模型保存路径
-	data       *model.BuildData   // 构建数据
-	model      *model.Live2dModel // Live2D 模型
-	dataPath   string             // 数据文件路径
-	downloader *Downloader        // 下载器实例
-	ModelName  string             // 模型名称
+	path       string                    // 模型保存路径
+	server     *config.AssetServerConfig // 模型所属 Bestdori 服务器
+	data       *model.BuildData          // 构建数据
+	model      *model.Live2dModel        // Live2D 模型
+	dataPath   string                    // 数据文件路径
+	downloader *Downloader               // 下载器实例
+	ModelName  string                    // 模型名称
 }
 
 // NewLive2dBuilder 创建新的 Live2D 构建器实例
 // 参数:
 //   - path: 模型保存路径
+//   - server: Bestdori 服务器配置
 //   - buildData: 构建数据
 //   - downloader: 下载器实例
 //   - modelName: 模型名称
@@ -254,12 +259,14 @@ type Live2dBuilder struct {
 //   - *Live2dBuilder: 新的 Live2D 构建器实例
 func NewLive2dBuilder(
 	path string,
+	server *config.AssetServerConfig,
 	buildData *model.BuildData,
 	downloader *Downloader,
 	modelName string,
 ) *Live2dBuilder {
 	return &Live2dBuilder{
 		path:       path,
+		server:     server,
 		data:       buildData,
 		model:      &model.Live2dModel{Motions: make(map[string][]model.MotionFile)},
 		dataPath:   filepath.Join(path, "data"),
@@ -285,7 +292,7 @@ func (b *Live2dBuilder) ProcessFile(
 	allowNotFound bool,
 ) (string, error) {
 	if _, statErr := os.Stat(filePath); os.IsNotExist(statErr) {
-		if downloadErr := b.downloader.DownloadBundleFile(ctx, bundleFile, filePath, allowNotFound); downloadErr != nil {
+		if downloadErr := b.downloader.DownloadBundleFile(ctx, b.server, bundleFile, filePath, allowNotFound); downloadErr != nil {
 			return "", fmt.Errorf("下载文件失败: %w", downloadErr)
 		}
 	}
@@ -521,7 +528,7 @@ func (b *Live2dBuilder) startWorkerPool(ctx context.Context, taskChan chan downl
 					errorChan <- errors.New("下载已取消")
 					return
 				default:
-					if downloadErr := b.downloader.DownloadBundleFile(ctx, task.bundleFile, task.filePath, task.allowNotFound); downloadErr != nil {
+					if downloadErr := b.downloader.DownloadBundleFile(ctx, b.server, task.bundleFile, task.filePath, task.allowNotFound); downloadErr != nil {
 						task.result <- downloadResult{err: fmt.Errorf("下载文件失败: %w", downloadErr)}
 						continue
 					}

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -17,8 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var DefaultServer = "jp"
-var DefaultServerConfig = config.DefaultAssetServerConfigTemplate(DefaultServer)
+const DefaultServer = "jp"
+
+// defaultServerConfig 返回默认的资源服务器配置副本，避免在包级别使用可变全局变量.
+func defaultServerConfig() config.AssetServerConfig {
+	return config.DefaultAssetServerConfigTemplate(DefaultServer)
+}
 
 // setupTest 设置测试环境.
 func setupTest(t *testing.T) {
@@ -86,7 +90,8 @@ func TestDownloadBundleFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			downloadErr := downloader.DownloadBundleFile(ctx, &DefaultServerConfig, tt.bundleFile, tt.filePath, false)
+			cfg := defaultServerConfig()
+			downloadErr := downloader.DownloadBundleFile(ctx, &cfg, tt.bundleFile, tt.filePath, false)
 
 			if tt.wantErr {
 				require.Error(t, downloadErr, "DownloadBundleFile() should return error for invalid file")
@@ -176,7 +181,8 @@ func TestLive2dBuilder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := downloader.NewLive2dBuilder(tt.path, &DefaultServerConfig, tt.buildData, d, "test_model")
+			cfg := defaultServerConfig()
+			builder := downloader.NewLive2dBuilder(tt.path, &cfg, tt.buildData, d, "test_model")
 			require.NotNil(t, builder, "NewLive2dBuilder() should not return nil")
 
 			constructErr := builder.Construct()

--- a/pkg/downloader/downloader_test.go
+++ b/pkg/downloader/downloader_test.go
@@ -17,6 +17,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var DefaultServer = "jp"
+var DefaultServerConfig = config.DefaultAssetServerConfigTemplate(DefaultServer)
+
 // setupTest 设置测试环境.
 func setupTest(t *testing.T) {
 	// 创建临时目录
@@ -83,7 +86,7 @@ func TestDownloadBundleFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			downloadErr := downloader.DownloadBundleFile(ctx, tt.bundleFile, tt.filePath, false)
+			downloadErr := downloader.DownloadBundleFile(ctx, &DefaultServerConfig, tt.bundleFile, tt.filePath, false)
 
 			if tt.wantErr {
 				require.Error(t, downloadErr, "DownloadBundleFile() should return error for invalid file")
@@ -173,7 +176,7 @@ func TestLive2dBuilder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			builder := downloader.NewLive2dBuilder(tt.path, tt.buildData, d, "test_model")
+			builder := downloader.NewLive2dBuilder(tt.path, &DefaultServerConfig, tt.buildData, d, "test_model")
 			require.NotNil(t, builder, "NewLive2dBuilder() should not return nil")
 
 			constructErr := builder.Construct()

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,8 +1,9 @@
 // Package log 提供日志功能
-package log //nolint:revive // package name 'log' intentionally matches functionality; avoids extra nesting
+package log
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -19,6 +20,7 @@ var (
 // Logger 提供日志功能.
 type Logger struct {
 	logger zerolog.Logger
+	writer io.Closer
 }
 
 // New 创建一个新的日志实例.
@@ -40,8 +42,20 @@ func New(logPath string) (*Logger, error) {
 
 	// 配置日志输出
 	logger := zerolog.New(logFile).With().Timestamp().Logger()
-	DefaultLogger = &Logger{logger: logger}
+	DefaultLogger = &Logger{
+		logger: logger,
+		writer: logFile,
+	}
 	return DefaultLogger, nil
+}
+
+// Close 关闭日志输出.
+func (l *Logger) Close() error {
+	if l == nil || l.writer == nil {
+		return nil
+	}
+
+	return l.writer.Close()
 }
 
 // Error 记录错误日志.

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,5 +1,5 @@
 // Package log 提供日志功能
-package log
+package log //nolint:revive // package name 'log' intentionally matches functionality; avoids extra nesting
 
 import (
 	"fmt"

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -4,6 +4,7 @@ package model
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -84,6 +85,31 @@ type Live2dAsset struct {
 
 func (l *Live2dAsset) String() string {
 	return fmt.Sprintf("%s (%s)", l.Costume, l.Server)
+}
+
+// CostumeLess 比较两个 Live2dAsset 的排序优先级 (用于排序).
+func CostumeLess(a, b Live2dAsset) bool {
+	aName := a.Costume
+	bName := b.Costume
+
+	// 如果包含 "live_event", 将其排在后面
+	aHasEvent := strings.Contains(aName, "live_event")
+	bHasEvent := strings.Contains(bName, "live_event")
+	if aHasEvent != bHasEvent {
+		return !aHasEvent
+	}
+
+	aParts := strings.Split(aName, "_")
+	bParts := strings.Split(bName, "_")
+	if len(aParts) > 1 && len(bParts) > 1 {
+		aID, aErr := strconv.Atoi(aParts[1])
+		bID, bErr := strconv.Atoi(bParts[1])
+		if aErr == nil && bErr == nil {
+			return aID < bID
+		}
+	}
+
+	return aName < bName
 }
 
 // MatchChara 表示匹配的角色信息

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -86,22 +86,6 @@ func (l *Live2dAsset) String() string {
 	return fmt.Sprintf("%s (%s)", l.Costume, l.Server)
 }
 
-func Parse(s string) (*Live2dAsset, error) {
-	l := strings.LastIndex(s, "(")
-	r := strings.LastIndex(s, ")")
-
-	if l == -1 || r == -1 || l >= r {
-		return nil, fmt.Errorf("错误的模型名称: %s", s)
-	}
-
-	obj := Live2dAsset{
-		Server:  strings.TrimSpace(s[l+1 : r]),
-		Costume: strings.TrimSpace(s[:l]),
-	}
-
-	return &obj, nil
-}
-
 // MatchChara 表示匹配的角色信息
 // 用于存储角色搜索的结果.
 type MatchChara struct {

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -87,10 +87,21 @@ func (l *Live2dAsset) String() string {
 	return fmt.Sprintf("%s (%s)", l.Costume, l.Server)
 }
 
+func sortableCostumeName(name string) string {
+	parts := strings.Split(name, "_")
+	if len(parts) >= 3 && parts[0] == "bili" {
+		if _, err := strconv.Atoi(parts[1]); err == nil {
+			return strings.Join(parts[1:], "_")
+		}
+	}
+
+	return name
+}
+
 // CostumeLess 比较两个 Live2dAsset 的排序优先级 (用于排序).
 func CostumeLess(a, b Live2dAsset) bool {
-	aName := a.Costume
-	bName := b.Costume
+	aName := sortableCostumeName(a.Costume)
+	bName := sortableCostumeName(b.Costume)
 
 	// 如果包含 "live_event", 将其排在后面
 	aHasEvent := strings.Contains(aName, "live_event")

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -2,7 +2,10 @@
 // 包括资源包文件、构建数据、动作文件、表情文件等类型
 package model
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // BundleFile 表示资源包文件
 // 用于描述从 Bestdori 下载的资源文件信息.
@@ -70,6 +73,33 @@ type Data struct {
 	Textures       []string                `json:"textures"`
 	Motions        map[string][]MotionFile `json:"motions"`
 	Expressions    []ExpressionFile        `json:"expressions"`
+}
+
+// Live2dAsset 表示 Live2D 模型资源信息
+// 用于存储资源映射及其所属服务器
+type Live2dAsset struct {
+	Server  string
+	Costume string
+}
+
+func (l *Live2dAsset) String() string {
+	return fmt.Sprintf("%s (%s)", l.Costume, l.Server)
+}
+
+func Parse(s string) (*Live2dAsset, error) {
+	l := strings.LastIndex(s, "(")
+	r := strings.LastIndex(s, ")")
+
+	if l == -1 || r == -1 || l >= r {
+		return nil, fmt.Errorf("错误的模型名称: %s", s)
+	}
+
+	obj := Live2dAsset{
+		Server:  strings.TrimSpace(s[l+1 : r]),
+		Costume: strings.TrimSpace(s[:l]),
+	}
+
+	return &obj, nil
 }
 
 // MatchChara 表示匹配的角色信息

--- a/pkg/model/types.go
+++ b/pkg/model/types.go
@@ -76,7 +76,7 @@ type Data struct {
 }
 
 // Live2dAsset 表示 Live2D 模型资源信息
-// 用于存储资源映射及其所属服务器
+// 用于存储资源映射及其所属服务器.
 type Live2dAsset struct {
 	Server  string
 	Costume string

--- a/pkg/model/types_test.go
+++ b/pkg/model/types_test.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCostumeLessTreatsBiliPrefixAsSameCharaSeries(t *testing.T) {
+	costumes := []Live2dAsset{
+		{Server: "jp", Costume: "016_cafe"},
+		{Server: "cn", Costume: "bili_016_collabo_ssr"},
+		{Server: "jp", Costume: "016_live_event_08_ssr"},
+		{Server: "jp", Costume: "016_delta"},
+	}
+
+	sort.Slice(costumes, func(i, j int) bool {
+		return CostumeLess(costumes[i], costumes[j])
+	})
+
+	require.Equal(t, []string{
+		"016_cafe",
+		"bili_016_collabo_ssr",
+		"016_delta",
+		"016_live_event_08_ssr",
+	}, []string{
+		costumes[0].Costume,
+		costumes[1].Costume,
+		costumes[2].Costume,
+		costumes[3].Costume,
+	})
+}

--- a/pkg/model/types_test.go
+++ b/pkg/model/types_test.go
@@ -1,14 +1,15 @@
-package model
+package model_test
 
 import (
 	"sort"
 	"testing"
 
+	"github.com/A-kirami/bestdori-live2d-downloader/pkg/model"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCostumeLessTreatsBiliPrefixAsSameCharaSeries(t *testing.T) {
-	costumes := []Live2dAsset{
+	costumes := []model.Live2dAsset{
 		{Server: "jp", Costume: "016_cafe"},
 		{Server: "cn", Costume: "bili_016_collabo_ssr"},
 		{Server: "jp", Costume: "016_live_event_08_ssr"},
@@ -16,7 +17,7 @@ func TestCostumeLessTreatsBiliPrefixAsSameCharaSeries(t *testing.T) {
 	}
 
 	sort.Slice(costumes, func(i, j int) bool {
-		return CostumeLess(costumes[i], costumes[j])
+		return model.CostumeLess(costumes[i], costumes[j])
 	})
 
 	require.Equal(t, []string{

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/A-kirami/bestdori-live2d-downloader/pkg/model"
 	"github.com/A-kirami/bestdori-live2d-downloader/pkg/version"
 
 	"slices"
@@ -97,8 +98,9 @@ func (i DownloadListItem) FilterValue() string { return i.Name }
 
 // listItem 表示列表项.
 type listItem struct {
-	title    string // 标题
-	selected bool   // 是否选中
+	title    string             // 标题
+	selected bool               // 是否选中
+	asset    *model.Live2dAsset // 对应的 Live2dAsset（如果有）
 }
 
 // Title 返回列表项的标题.
@@ -118,27 +120,27 @@ func (i listItem) FilterValue() string { return i.title }
 // Model 表示 TUI 模型
 // 包含所有 UI 组件和状态.
 type Model struct {
-	Items            map[string]*DownloadItem // 下载项映射，key 为项目名称，value 为下载项
-	ItemOrder        []string                 // 下载项顺序列表
-	Width            int                      // 界面宽度
-	Quitting         bool                     // 是否正在退出程序
-	TextInput        textinput.Model          // 文本输入框组件
-	Live2dList       list.Model               // Live2D 列表组件
-	DownloadList     list.Model               // 下载列表组件
-	SelectedIDs      []int                    // 选中的项目 ID 列表
-	State            string                   // 当前状态
-	SearchChan       chan string              // 搜索通道，用于处理搜索请求
-	SelectChan       chan []string            // 选择通道，用于处理选择请求
-	Spinner          spinner.Model            // 加载动画组件
-	CurrentCharaName string                   // 当前角色名称
-	ExtraCharaName   string                   // 额外角色名称
-	program          *tea.Program             // TUI 程序实例
-	cancelChan       chan struct{}            // 取消通道，用于取消操作
-	Ctx              context.Context          // 上下文，用于控制操作的生命周期
-	Cancel           context.CancelFunc       // 取消函数，用于取消上下文
-	ErrorMessage     string                   // 错误消息
-	TotalModels      int                      // 总模型数量
-	CompletedModels  int                      // 已完成的模型数量
+	Items            map[string]*DownloadItem  // 下载项映射，key 为项目名称，value 为下载项
+	ItemOrder        []string                  // 下载项顺序列表
+	Width            int                       // 界面宽度
+	Quitting         bool                      // 是否正在退出程序
+	TextInput        textinput.Model           // 文本输入框组件
+	Live2dList       list.Model                // Live2D 列表组件
+	DownloadList     list.Model                // 下载列表组件
+	SelectedIDs      []int                     // 选中的项目 ID 列表
+	State            string                    // 当前状态
+	SearchChan       chan string               // 搜索通道，用于处理搜索请求
+	SelectChan       chan []*model.Live2dAsset // 选择通道，用于处理选择请求
+	Spinner          spinner.Model             // 加载动画组件
+	CurrentCharaName string                    // 当前角色名称
+	ExtraCharaName   string                    // 额外角色名称
+	program          *tea.Program              // TUI 程序实例
+	cancelChan       chan struct{}             // 取消通道，用于取消操作
+	Ctx              context.Context           // 上下文，用于控制操作的生命周期
+	Cancel           context.CancelFunc        // 取消函数，用于取消上下文
+	ErrorMessage     string                    // 错误消息
+	TotalModels      int                       // 总模型数量
+	CompletedModels  int                       // 已完成的模型数量
 }
 
 // DownloadDelegate 用于下载进度列表的代理
@@ -215,7 +217,7 @@ func NewModel() Model {
 		DownloadList:    downloadList,
 		State:           StateInput,
 		SearchChan:      make(chan string, 1),
-		SelectChan:      make(chan []string, 1),
+		SelectChan:      make(chan []*model.Live2dAsset, 1),
 		Spinner:         s,
 		cancelChan:      make(chan struct{}), // 初始化取消通道
 		Ctx:             ctx,
@@ -232,7 +234,7 @@ func (m *Model) Init() tea.Cmd {
 
 // UpdateListMsg 表示更新列表消息.
 type UpdateListMsg struct {
-	Items []string // 列表项
+	Items []*model.Live2dAsset // 列表项
 }
 
 // UpdateDownloadListMsg 表示更新下载列表消息.
@@ -352,8 +354,8 @@ func (m *Model) handleSelectAll() {
 func (m *Model) handleListEnter() (tea.Model, tea.Cmd) {
 	selected := m.GetSelectedItems()
 	if len(selected) > 0 {
-		for _, name := range selected {
-			m.AddDownloadItem(name, 1)
+		for _, asset := range selected {
+			m.AddDownloadItem(asset.String(), 1)
 		}
 		m.State = StateDownloading
 		// 设置总体进度并立即更新标题
@@ -399,10 +401,15 @@ func (m *Model) handleDownloadingState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // handleUpdateListMsg 处理更新列表消息.
 func (m *Model) handleUpdateListMsg(msg UpdateListMsg) (tea.Model, tea.Cmd) {
 	listItems := make([]list.Item, len(msg.Items))
-	for i, item := range msg.Items {
+	for i, asset := range msg.Items {
+		title := ""
+		if asset != nil {
+			title = asset.String()
+		}
 		listItems[i] = listItem{
-			title:    item,
+			title:    title,
 			selected: false,
+			asset:    asset,
 		}
 	}
 	m.Live2dList.SetItems(listItems)
@@ -650,12 +657,17 @@ func (m *Model) updateDownloadList() {
 	m.DownloadList.SetItems(items)
 }
 
-func (m *Model) SetLive2DList(items []string) {
+func (m *Model) SetLive2DList(items []*model.Live2dAsset) {
 	listItems := make([]list.Item, len(items))
-	for i, item := range items {
+	for i, asset := range items {
+		title := ""
+		if asset != nil {
+			title = asset.String()
+		}
 		listItems[i] = listItem{
-			title:    item,
+			title:    title,
 			selected: false,
+			asset:    asset,
 		}
 	}
 	m.Live2dList.SetItems(listItems)
@@ -664,38 +676,47 @@ func (m *Model) SetLive2DList(items []string) {
 	m.State = StateList
 }
 
-func (m *Model) GetSelectedItems() []string {
+func (m *Model) GetSelectedItems() []*model.Live2dAsset {
 	// 使用 map 来确保唯一性
-	uniqueItems := make(map[string]struct{})
+	unique := make(map[string]*model.Live2dAsset)
 	for _, id := range m.SelectedIDs {
 		if id < len(m.Live2dList.Items()) {
 			if item, ok := m.Live2dList.Items()[id].(listItem); ok {
-				uniqueItems[item.title] = struct{}{}
+				if item.asset != nil {
+					unique[item.asset.String()] = item.asset
+				} else {
+					unique[item.title] = nil
+				}
 			}
 		}
 	}
 
 	// 将 map 转换回切片
-	selected := make([]string, 0, len(uniqueItems))
-	for item := range uniqueItems {
-		selected = append(selected, item)
+	selected := make([]*model.Live2dAsset, 0, len(unique))
+	for _, asset := range unique {
+		selected = append(selected, asset)
 	}
 
-	// 对选中的项目进行排序
+	// 对选中的项目进行排序（基于字符串表示）
 	sort.Slice(selected, func(i, j int) bool {
-		// 提取服装ID（模型名称中的数字部分）
-		iParts := strings.Split(selected[i], "_")
-		jParts := strings.Split(selected[j], "_")
+		si := ""
+		sj := ""
+		if selected[i] != nil {
+			si = selected[i].String()
+		}
+		if selected[j] != nil {
+			sj = selected[j].String()
+		}
 
-		// 如果包含"live_event"，将其排在后面
-		iHasEvent := strings.Contains(selected[i], "live_event")
-		jHasEvent := strings.Contains(selected[j], "live_event")
+		iParts := strings.Split(si, "_")
+		jParts := strings.Split(sj, "_")
 
+		iHasEvent := strings.Contains(si, "live_event")
+		jHasEvent := strings.Contains(sj, "live_event")
 		if iHasEvent != jHasEvent {
 			return !iHasEvent
 		}
 
-		// 比较服装ID
 		if len(iParts) > 1 && len(jParts) > 1 {
 			iID, iErr := strconv.Atoi(iParts[1])
 			jID, jErr := strconv.Atoi(jParts[1])
@@ -704,8 +725,7 @@ func (m *Model) GetSelectedItems() []string {
 			}
 		}
 
-		// 如果无法比较ID，则按字符串排序
-		return selected[i] < selected[j]
+		return si < sj
 	})
 
 	return selected
@@ -715,7 +735,7 @@ func (m *Model) GetSearchChan() <-chan string {
 	return m.SearchChan
 }
 
-func (m *Model) GetSelectChan() <-chan []string {
+func (m *Model) GetSelectChan() <-chan []*model.Live2dAsset {
 	return m.SelectChan
 }
 

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -697,38 +697,43 @@ func (m *Model) GetSelectedItems() []*model.Live2dAsset {
 		selected = append(selected, asset)
 	}
 
-	// 对选中的项目进行排序（基于字符串表示）
+	// 对选中的项目进行排序，比较逻辑委托给 selectedLess
 	sort.Slice(selected, func(i, j int) bool {
-		si := ""
-		sj := ""
-		if selected[i] != nil {
-			si = selected[i].String()
-		}
-		if selected[j] != nil {
-			sj = selected[j].String()
-		}
-
-		iParts := strings.Split(si, "_")
-		jParts := strings.Split(sj, "_")
-
-		iHasEvent := strings.Contains(si, "live_event")
-		jHasEvent := strings.Contains(sj, "live_event")
-		if iHasEvent != jHasEvent {
-			return !iHasEvent
-		}
-
-		if len(iParts) > 1 && len(jParts) > 1 {
-			iID, iErr := strconv.Atoi(iParts[1])
-			jID, jErr := strconv.Atoi(jParts[1])
-			if iErr == nil && jErr == nil {
-				return iID < jID
-			}
-		}
-
-		return si < sj
+		return selectedLess(selected[i], selected[j])
 	})
 
 	return selected
+}
+
+// selectedLess 比较两个已选项目的排序顺序.
+func selectedLess(a, b *model.Live2dAsset) bool {
+	sa := ""
+	sb := ""
+	if a != nil {
+		sa = a.String()
+	}
+	if b != nil {
+		sb = b.String()
+	}
+
+	aParts := strings.Split(sa, "_")
+	bParts := strings.Split(sb, "_")
+
+	aHasEvent := strings.Contains(sa, "live_event")
+	bHasEvent := strings.Contains(sb, "live_event")
+	if aHasEvent != bHasEvent {
+		return !aHasEvent
+	}
+
+	if len(aParts) > 1 && len(bParts) > 1 {
+		aID, aErr := strconv.Atoi(aParts[1])
+		bID, bErr := strconv.Atoi(bParts[1])
+		if aErr == nil && bErr == nil {
+			return aID < bID
+		}
+	}
+
+	return sa < sb
 }
 
 func (m *Model) GetSearchChan() <-chan string {

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -565,7 +565,7 @@ func (m *Model) View() string {
 	case StateLoading:
 		s.WriteString(m.TextInput.View())
 		s.WriteString("\n\n")
-		s.WriteString(fmt.Sprintf("%s 正在搜索角色...", m.Spinner.View()))
+		fmt.Fprintf(&s, "%s 正在搜索角色...", m.Spinner.View())
 		s.WriteString("\n\n")
 		s.WriteString(helpStyle("按 Esc 或 Ctrl+C 退出"))
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,5 +1,5 @@
 // Package version 提供了版本信息
-package version
+package version //nolint:revive // package name 'version' intentionally used for project version info
 
 import "fmt"
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,5 +1,5 @@
 // Package version 提供了版本信息
-package version //nolint:revive // package name 'version' intentionally used for project version info
+package version
 
 import "fmt"
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

Bestdori 支持 jp, cn 等数据包, 在 `config.go` 中设置不同数据包对应的 API 配置.

在检索模型时使用 `Live2dAsset` 为模型附加数据包标签, 并为对应模型构建下载构建器追加 API 配置 (而不是直接获取全局配置).

在 tui 呈现时, 使用 `<模型名称> (<数据包>)` 作为每个模型的唯一标签. 除此以外用户使用上没有区别.

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

实现 #1.

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

##### 必要说明

多服务器的支持产生了大改动, 但并没有涉及架构变化, 且未对代码和实际使用造成行为上的不符合预期.
姑且认为不存在破坏性更改.

##### 使用截图

<img width="919" height="504" alt="屏幕截图 2026-02-28 205006" src="https://github.com/user-attachments/assets/eb82ef3c-afc1-466a-9ff1-ec8350d55139" />

<img width="919" height="504" alt="屏幕截图 2026-02-28 205014" src="https://github.com/user-attachments/assets/a8d90cb0-0b55-4bbb-afc3-9a333453d674" />

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
