### PR TITLE
:bug: 模型文件先尝试下载到临时位置, 避免跳过中断文件

### DIFF
--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -234,7 +234,7 @@ func (d *Downloader) DownloadBundleFile(
 
 	// 写入文件内容
 	writeErr := d.writeFileContent(tempFile, resp, tempFilePath)
-	tempFile.Close()
+	_ = tempFile.Close()
 	if writeErr != nil {
 		return writeErr
 	}

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -230,17 +230,19 @@ func (d *Downloader) DownloadBundleFile(
 	if createErr != nil {
 		return createErr
 	}
-	// defer tempFile.Close() // 手动关闭
 
 	// 写入文件内容
-	writeErr := d.writeFileContent(tempFile, resp, tempFilePath)
-	_ = tempFile.Close()
-	if writeErr != nil {
+	if writeErr := func() error {
+		defer tempFile.Close()
+		return d.writeFileContent(tempFile, resp, tempFilePath)
+	}(); writeErr != nil {
+		_ = os.Remove(tempFilePath)
 		return writeErr
 	}
 
 	// 重命名为目标文件
 	if renameErr := os.Rename(tempFilePath, filePath); renameErr != nil {
+		_ = os.Remove(tempFilePath)
 		return renameErr
 	}
 

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -224,16 +224,24 @@ func (d *Downloader) DownloadBundleFile(
 		return nil
 	}
 
-	// 创建文件和目录
-	file, createErr := d.createFileAndDirectory(filePath)
+	// 创建临时文件和目录
+	tempFilePath := filePath + ".tmp"
+	tempFile, createErr := d.createFileAndDirectory(tempFilePath)
 	if createErr != nil {
 		return createErr
 	}
-	defer file.Close()
+	// defer tempFile.Close() // 手动关闭
 
 	// 写入文件内容
-	if writeErr := d.writeFileContent(file, resp, filePath); writeErr != nil {
+	writeErr := d.writeFileContent(tempFile, resp, tempFilePath)
+	tempFile.Close()
+	if writeErr != nil {
 		return writeErr
+	}
+
+	// 重命名为目标文件
+	if renameErr := os.Rename(tempFilePath, filePath); renameErr != nil {
+		return renameErr
 	}
 
 	log.DefaultLogger.Info().Str("filePath", filePath).Msg("文件下载完成")


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

模型文件先下载到后缀为 `.tmp` 的临时文件, 成功时再重命名.

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

fix: #3 

#3 原来的缓存机制确实有效, 但过于复杂, 且需要大量修改测试.
此 PR 通过移除中断文件的产生, 直接规避了此错误的发生, 同时几乎不影响原来的下载逻辑.

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
